### PR TITLE
Pipeline: build.fhir.org dev preview, preprod on merge, hardened prod release

### DIFF
--- a/.github/workflows/build-review-publish.yml
+++ b/.github/workflows/build-review-publish.yml
@@ -1,15 +1,23 @@
-name: IG build → working+milestone previews → gated publish (reusable)
+name: IG build → preprod (on merge) → gated prod publish (reusable)
 
 # CENTRALIZED, reusable (workflow_call) pipeline for the AU FHIR IGs. ONE source of truth lives here
 # in hl7au/publications; each IG repo (au-fhir-base, au-fhir-ps, au-fhir-core) carries only a thin
-# caller stub that forwards its push/PR/tag/dispatch events to this workflow. This replaces the
-# per-repo copies of build-review-publish.yml that had begun to drift (S3 vs GitHub Pages previews;
-# the history-asset seeding fix present in only one; inconsistent package-registry.json handling).
+# caller stub that forwards its push/PR/tag/dispatch events to this workflow.
 #
 # WHAT IT DOES: renders the IG ONCE (publication mode), then runs go-publish TWICE off that single
 # render (-reuse-build → the 2nd is ~100s, not another render) to produce BOTH a WORKING and a
-# MILESTONE build; deploys both side-by-side as a per-branch S3 preview; and (gated) publishes to
-# prod S3. github.* context inside this workflow reflects the CALLER's triggering event.
+# MILESTONE build, packaged as one reviewable .zip artifact. Then:
+#   - DEVELOPER PREVIEW is HL7 International's CI build (build.fhir.org/ig/<org>/<repo>/branches/<branch>),
+#     driven by HL7's own auto-builder — NOT this pipeline. We just link to it + attach the .zip.
+#     (Our own S3 preview is retained but OFF by default — set enable_s3_preview=true to re-enable it
+#      when we specifically need to validate our own pipeline/publisher output.)
+#   - On MERGE TO master → auto-deploy to PREPROD (preprod.hl7.org.au) for staging validation. Mode
+#     (milestone vs working) is AUTO-DETECTED from publication-request.json `status` (the FHIR-standard
+#     signal): release/trial-use/normative/normative+trial-use → milestone (becomes 'current');
+#     draft/ballot/preview/update/ci-build → working (versioned snapshot, not current).
+#   - On a v* TAG push → GATED publish to PROD (hl7.org.au), milestone, behind the caller repo's
+#     `production` environment, with a release guard + CloudFront invalidation + post-publish verify.
+# github.* context inside this workflow reflects the CALLER's triggering event.
 #
 # PER-IG PARAMETER — `subtree`:
 #   - ""          → this IG owns the /fhir ROOT (au-base). Syncs out/<mode>/fhir → s3://<bucket>/fhir.
@@ -20,12 +28,13 @@ name: IG build → working+milestone previews → gated publish (reusable)
 #   Shared root files are seeded from the LIVE prod copies, so go-publish inserts this IG's entry and
 #   the sibling IGs' entries survive. All uploads are additive — never --delete.
 #
-# DEPLOY TARGETS (current approval state — see publications/terraform/cloudfront + docs):
-#   - previews S3 bucket (hl7au-fhir-ig-previews): CI-writable NOW. Per-branch previews land here.
-#   - prod (hl7au-fhir-ig): the publish jobs are GATED on the caller repo's `production` environment
-#     (required reviewers; deployment-branch rule = master + v* tags). Built but dormant until approved.
-#   - previews.hl7.org.au DNS: not live yet — the URL report leads with the working S3 website
-#     endpoint and prints the (pending) previews.hl7.org.au URL labelled "not live yet".
+# DEPLOY TARGETS:
+#   - build.fhir.org (HL7 CI): developer previews — external, not written by us.
+#   - preprod (hl7au-fhir-ig-mirror / preprod.hl7.org.au): auto-deploy on merge to master. Ungated.
+#   - prod (hl7au-fhir-ig / hl7.org.au): GATED on the caller repo's `production` environment
+#     (required reviewers; deployment-branch rule = master + v* tags). v* tag only.
+#   - previews S3 (hl7au-fhir-ig-previews / previews.hl7.org.au): retained but OFF by default
+#     (enable_s3_preview=true to re-enable our own preview channel).
 #
 # TEMP: fetches the combined custom publisher.jar (KyleOps/fhir-ig-publisher release au-pipeline-combined:
 # #1327 cloud redirects + A2 dynamic publish-box/page-versions + skip-version-tree + A3 source viewers +
@@ -52,9 +61,13 @@ on:
         description: "Publish the WORKING build to prod S3 (versioned snapshot, NOT current; gated)."
         type: boolean
         default: false
+      enable_s3_preview:
+        description: "Also deploy our own S3 preview channel (previews.hl7.org.au). Off by default — build.fhir.org is the dev preview."
+        type: boolean
+        default: false
 
 permissions:
-  id-token: write   # OIDC → AWS (previews sync + gated prod publish)
+  id-token: write   # OIDC → AWS (preprod deploy + gated prod publish + optional S3 preview)
   contents: read
 
 concurrency:
@@ -67,7 +80,10 @@ env:
   PUBLICATIONS_REF: master
   TX_SERVER: https://tx.fhir.org
   PROD_BUCKET: hl7au-fhir-ig
+  PREPROD_BUCKET: hl7au-fhir-ig-mirror
   PREVIEWS_BUCKET: hl7au-fhir-ig-previews
+  PROD_DIST: E2U6NB1JDLY5NT
+  PREPROD_DIST: E1U9JOMOLLTC27
   AWS_ROLE: arn:aws:iam::966489602583:role/ghactions_publications_oidc
   AWS_REGION: ap-southeast-2
 
@@ -79,6 +95,10 @@ jobs:
       slug: ${{ steps.meta.outputs.slug }}
       ver: ${{ steps.render.outputs.ver }}
       own: ${{ steps.meta.outputs.own }}
+      status: ${{ steps.detect.outputs.status }}
+      version: ${{ steps.detect.outputs.version }}
+      pubmode: ${{ steps.detect.outputs.pubmode }}
+      release_ok: ${{ steps.detect.outputs.release_ok }}
     steps:
       - name: Compute build label (branch / pr-N / tag / dispatch ref) + owned path
         id: meta
@@ -101,6 +121,33 @@ jobs:
         with:
           ref: ${{ inputs.ref || github.sha }}
           path: ig-src
+
+      # Auto-detect milestone vs working from the FHIR-standard `status` in publication-request.json
+      # (NOT the version number — AU history shows clean versions like 2.0.0 shipped as `preview` and
+      # 1.0.0 as `ballot`; the versions that became 'current' were all `trial-use`). The publisher's
+      # `mode` (working/milestone) and `status` are independent; here `status` drives the choice:
+      #   release | trial-use | normative | normative+trial-use → MILESTONE (becomes 'current')
+      #   draft | ballot | preview | update | ci-build | (other) → WORKING (versioned, not current)
+      # release_ok additionally requires a clean SemVer release version (no -prerelease suffix), used
+      # as the prod-publish guard so a -ci-build/preview can never be published to prod as 'current'.
+      - name: Detect publication mode (status-driven)
+        id: detect
+        working-directory: ig-src
+        run: |
+          status=$(node -e 'const fs=require("fs");try{process.stdout.write((JSON.parse(fs.readFileSync("publication-request.json","utf8")).status||"").toLowerCase())}catch(e){}')
+          version=$(node -e 'const fs=require("fs");try{process.stdout.write(JSON.parse(fs.readFileSync("publication-request.json","utf8")).version||"")}catch(e){}')
+          case "$status" in
+            release|trial-use|normative|normative+trial-use) pubmode=milestone ;;
+            *) pubmode=working ;;
+          esac
+          # clean release version = X.Y.Z with no -prerelease suffix
+          relok=false
+          if printf '%s' "$version" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+$' && [ "$pubmode" = "milestone" ]; then relok=true; fi
+          echo "status=$status"   >> "$GITHUB_OUTPUT"
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+          echo "pubmode=$pubmode" >> "$GITHUB_OUTPUT"
+          echo "release_ok=$relok" >> "$GITHUB_OUTPUT"
+          echo "status='$status' version='$version' → pubmode=$pubmode (clean-release=$relok)"
 
       - name: Checkout publish-setup.json + templates (sparse, from publications)
         uses: actions/checkout@v4
@@ -256,14 +303,39 @@ jobs:
           path: preview-${{ steps.meta.outputs.slug }}.tar.gz
           retention-days: 14
 
-  # Per-branch / per-PR live PREVIEWS on the previews S3 bucket — BOTH the working and milestone
-  # renders. Synced to s3://hl7au-fhir-ig-previews/<slug>/{working,milestone}/ so branches coexist;
-  # stale previews auto-expire via the bucket's 30-day lifecycle rule. No canonical CloudFront
-  # function here: baked absolute hl7.org.au canonicals resolve to PROD, so this is good for "does it
-  # render / how does the milestone look", not for canonical/version redirects. The dynamic publish-box
-  # DOES resolve (its JS reads the preview's own package-list.json same-origin).
+      # Developer preview = HL7 International's CI build (build.fhir.org), driven by HL7's own
+      # auto-builder. We don't deploy it — just surface the link + the downloadable .zip. The HL7 CI
+      # build URL is /ig/<org>/<repo> for the default branch and /ig/<org>/<repo>/branches/<branch>
+      # otherwise. (Tag/dispatch runs aren't branch builds, so we point at the default-branch build.)
+      - name: Report build outputs (build.fhir.org preview + downloadable zip)
+        run: |
+          repo="${{ github.repository }}"            # e.g. hl7au/au-fhir-base
+          default="${{ github.event.repository.default_branch }}"
+          if [ "${{ github.event_name }}" = "pull_request" ]; then branch="${{ github.head_ref }}"; else branch="${{ github.ref_name }}"; fi
+          base="https://build.fhir.org/ig/$repo"
+          if [ "${{ github.event_name }}" = "push" ] && [ "${{ github.ref_type }}" = "tag" ]; then
+            url="$base"                              # tag build → default-branch CI build
+          elif [ -n "$branch" ] && [ "$branch" != "$default" ]; then
+            url="$base/branches/$branch"
+          else
+            url="$base"
+          fi
+          {
+            echo "### Developer preview & build output";
+            echo "";
+            echo "- **HL7 CI preview (build.fhir.org):** $url/  _(rendered by HL7 International's auto-builder; allow a few minutes after push)_";
+            echo "- **Reviewable build (this run):** the \`site-${{ steps.meta.outputs.slug }}\` artifact below — a tar.gz of the working + milestone renders.";
+            echo "- detected publication mode: **${{ steps.detect.outputs.pubmode }}** (status \`${{ steps.detect.outputs.status }}\`, version \`${{ steps.detect.outputs.version }}\`)";
+          } >> "$GITHUB_STEP_SUMMARY"
+
+  # OUR OWN per-branch S3 previews (previews.hl7.org.au) — RETAINED but OFF by default. The developer
+  # preview channel is HL7 International's build.fhir.org (see the build job's report). Re-enable this
+  # (enable_s3_preview=true) only when we need to validate our OWN pipeline/publisher output (e.g.
+  # testing the dynamic publish-box, the combined jar, or canonical behaviour) rather than the content.
+  # Deploys BOTH the working and milestone renders to s3://hl7au-fhir-ig-previews/<slug>/{working,milestone}/.
   preview-s3:
     needs: build
+    if: ${{ inputs.enable_s3_preview }}
     runs-on: ubuntu-latest
     steps:
       - name: Download built previews
@@ -335,8 +407,56 @@ jobs:
             echo "";
             echo "_Working = the new version as a non-current preview. Milestone = the same version promoted to";
             echo "current (publish box reads 'this is the current version'; old versions untouched via dynamic-publish-box)._";
-            echo "_Primary links use the S3 website endpoint (live now). Once the previews.hl7.org.au DNS is approved,";
-            echo "the same paths resolve under \`$dnsbase/working/$own/$ver/index.html\` (not live yet)._";
+            echo "_Primary links use the S3 website endpoint. Once the previews.hl7.org.au DNS is in use,";
+            echo "the same paths resolve under \`$dnsbase/working/$own/$ver/index.html\`._";
+          } >> "$GITHUB_STEP_SUMMARY"
+
+  # AUTO-DEPLOY TO PREPROD on a merge to master — the staging/validation environment before a prod
+  # release. UNGATED (preprod is not prod). Deploys the AUTO-DETECTED mode (milestone vs working, from
+  # publication-request.json `status`): a release/trial-use status lands as the candidate 'current' so
+  # preprod shows exactly what prod will look like; a draft/ballot/preview/ci-build status lands as a
+  # non-current versioned snapshot. Same additive owned-subtree + shared-root-files model as prod, but
+  # to the mirror bucket. preprod mirrors prod, so seeding the lean -web from live prod (in the build
+  # job) is correct here too. CloudFront (CachingOptimized) is invalidated so the change shows promptly.
+  deploy-preprod:
+    needs: build
+    if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download built site
+        uses: actions/download-artifact@v4
+        with: { name: "site-${{ needs.build.outputs.slug }}" }
+      - name: Configure AWS credentials from GitHub OIDC
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ env.AWS_ROLE }}
+          aws-region: ${{ env.AWS_REGION }}
+      - name: Deploy detected mode to preprod S3 (mirror bucket; additive)
+        run: |
+          aws configure set default.s3.max_concurrent_requests 64
+          aws configure set default.s3.max_queue_size 10000
+          own="${{ needs.build.outputs.own }}"; sub="${{ inputs.subtree }}"
+          m="${{ needs.build.outputs.pubmode }}"   # milestone | working (auto-detected from status)
+          echo "Deploying '$m' build to preprod (status=${{ needs.build.outputs.status }}, version=${{ needs.build.outputs.version }})"
+          mkdir -p out && tar -xzf "preview-${{ needs.build.outputs.slug }}.tar.gz" -C out
+          test -d "out/$m/$own" || { echo "::error::'$m' build missing in artifact — not deploying to preprod"; exit 1; }
+          aws s3 sync "out/$m/$own" "s3://$PREPROD_BUCKET/$own" --only-show-errors
+          if [ -n "$sub" ]; then
+            aws s3 cp out/$m/fhir/package-feed.xml      "s3://$PREPROD_BUCKET/fhir/package-feed.xml"      --only-show-errors
+            aws s3 cp out/$m/fhir/publication-feed.xml  "s3://$PREPROD_BUCKET/fhir/publication-feed.xml"  --only-show-errors
+          fi
+          [ -f out/$m/package-registry.json ] && aws s3 cp out/$m/package-registry.json "s3://$PREPROD_BUCKET/package-registry.json" --only-show-errors || true
+      - name: Invalidate preprod CloudFront
+        run: aws cloudfront create-invalidation --distribution-id "$PREPROD_DIST" --paths "/*" >/dev/null
+      - name: Report preprod URL
+        run: |
+          own="${{ needs.build.outputs.own }}"; ver="${{ needs.build.outputs.ver }}"
+          {
+            echo "### Deployed to preprod (staging)";
+            echo "- mode: **${{ needs.build.outputs.pubmode }}** (status \`${{ needs.build.outputs.status }}\`, version \`${{ needs.build.outputs.version }}\`)";
+            echo "- https://preprod.hl7.org.au/$own/$ver/index.html";
+            echo "- directory of versions: https://preprod.hl7.org.au/$own/history.html";
+            echo "_Validate here, then cut a prod release by pushing a \`v*\` tag (gated by the production environment)._";
           } >> "$GITHUB_STEP_SUMMARY"
 
   # Promote the MILESTONE build to PROD — gated by the caller repo's `production` environment (required
@@ -348,6 +468,16 @@ jobs:
     runs-on: ubuntu-latest
     environment: production
     steps:
+      # Release guard: a prod milestone must be a clean SemVer release (X.Y.Z, no -prerelease suffix)
+      # with a milestone status (release/trial-use/normative). Blocks accidentally publishing a
+      # -ci-build/draft/ballot/preview as prod 'current'. (release_ok is computed in the build job.)
+      - name: Guard — require a clean release version + milestone status
+        run: |
+          if [ "${{ needs.build.outputs.release_ok }}" != "true" ]; then
+            echo "::error::Refusing to publish to PROD: version='${{ needs.build.outputs.version }}' status='${{ needs.build.outputs.status }}'. A prod milestone needs a clean release version (X.Y.Z) and a release/trial-use/normative status. Set version + status in publication-request.json, then tag v<version>."
+            exit 1
+          fi
+          echo "Release guard OK: version=${{ needs.build.outputs.version }} status=${{ needs.build.outputs.status }}"
       - name: Download reviewed previews
         uses: actions/download-artifact@v4
         with: { name: "site-${{ needs.build.outputs.slug }}" }
@@ -376,6 +506,30 @@ jobs:
           fi
           # (c) package-registry.json is at the WEB ROOT (outside fhir/) for EVERY IG — upload it
           [ -f out/milestone/package-registry.json ] && aws s3 cp out/milestone/package-registry.json "s3://$PROD_BUCKET/package-registry.json" --only-show-errors || echo "no package-registry.json in output — skipping"
+      - name: Invalidate prod CloudFront
+        run: aws cloudfront create-invalidation --distribution-id "$PROD_DIST" --paths "/*" >/dev/null
+      # Post-publish verification: the new version's landing page must be live (200) on prod, and the
+      # canonical 'current' page must resolve. A non-200 fails the run so a broken publish is loud.
+      - name: Verify prod publish
+        run: |
+          own="${{ needs.build.outputs.own }}"; ver="${{ needs.build.outputs.ver }}"
+          base="https://hl7.org.au/$own"
+          fail=0
+          for u in "$base/$ver/index.html" "$base/index.html"; do
+            for attempt in 1 2 3 4 5; do
+              code=$(curl -s -o /dev/null -w '%{http_code}' "$u" || echo 000)
+              [ "$code" = "200" ] && break
+              sleep 15
+            done
+            if [ "$code" = "200" ]; then echo "OK   $u"; else echo "::error::FAIL ($code) $u"; fail=1; fi
+          done
+          {
+            echo "### Published to prod";
+            echo "- version: **${{ needs.build.outputs.version }}** (status \`${{ needs.build.outputs.status }}\`)";
+            echo "- $base/$ver/index.html";
+            echo "- current: $base/index.html";
+          } >> "$GITHUB_STEP_SUMMARY"
+          exit $fail
 
   # Publish the WORKING build to PROD — the common case (preview/ballot/draft). Gated by the same
   # `production` environment. Dispatch-only (publish_working=true), mutually exclusive with
@@ -409,3 +563,17 @@ jobs:
             aws s3 cp out/working/fhir/publication-feed.xml  "s3://$PROD_BUCKET/fhir/publication-feed.xml"  --only-show-errors
           fi
           [ -f out/working/package-registry.json ] && aws s3 cp out/working/package-registry.json "s3://$PROD_BUCKET/package-registry.json" --only-show-errors || echo "no package-registry.json in output — skipping"
+      - name: Invalidate prod CloudFront
+        run: aws cloudfront create-invalidation --distribution-id "$PROD_DIST" --paths "/*" >/dev/null
+      - name: Verify prod publish (new version dir is live)
+        run: |
+          own="${{ needs.build.outputs.own }}"; ver="${{ needs.build.outputs.ver }}"
+          u="https://hl7.org.au/$own/$ver/index.html"
+          for attempt in 1 2 3 4 5; do
+            code=$(curl -s -o /dev/null -w '%{http_code}' "$u" || echo 000)
+            [ "$code" = "200" ] && break
+            sleep 15
+          done
+          if [ "$code" = "200" ]; then echo "OK $u"; else echo "::error::FAIL ($code) $u"; exit 1; fi
+          echo "### Published WORKING build to prod" >> "$GITHUB_STEP_SUMMARY"
+          echo "- $u (versioned snapshot; 'current' unchanged)" >> "$GITHUB_STEP_SUMMARY"

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -88,3 +88,33 @@ ungated; only prod publish pauses for a human approval. Set up idempotently via 
 The full 27-version prod migration (apply dynamic-publish-box to all historical versions, fixing live
 page-version errors) is **deferred** — the corrected content already lives on the preprod mirror, so it's
 a flip when ready. Optional backfill flagged to Brett.
+
+## D12 — Developer previews = HL7 build.fhir.org; our S3 preview retained but off
+Discussed with Brett: HL7 International already builds per-branch developer previews at
+`build.fhir.org/ig/<org>/<repo>/branches/<branch>/` (via HL7's own Azure auto-builder). So the pipeline
+**no longer deploys our own S3 preview by default** — the build job just links the build.fhir.org URL +
+attaches the reviewable working+milestone `.zip`. Our `preview-s3` job is **retained but gated off**
+behind a new `enable_s3_preview` input (default false); re-enable only to validate our *own*
+pipeline/publisher output (dynamic publish-box, combined jar, canonical behaviour). Supersedes the
+"previews on every push" part of D9 (the previews bucket/host stay provisioned).
+
+## D13 — Milestone vs working is detected from `status`, NOT the version number
+Researched the FHIR/SemVer standard + AU's own published history. **Whole-number ≠ milestone:** in
+`package-list.json`, `2.0.0` shipped as `preview` and `1.0.0` as `ballot`, while every version that
+became **current** (5.0.0, 4.1.0, 4.0.0, 1.0.2) was `trial-use`. Per SemVer the `-suffix` only marks a
+pre-release; the IG-publication milestone signal is the **`status`** field (publisher treats `mode` and
+`status` as independent). So the pipeline auto-detects from `publication-request.json` `status`:
+`release`/`trial-use`/`normative`/`normative+trial-use` → **milestone** (becomes "current"); everything
+else (`draft`/`ballot`/`preview`/`update`/`ci-build`) → **working**. The team controls it the standard
+FHIR way — by editing `version` + `status` — instead of the pipeline hardcoding a mode.
+
+## D14 — Preprod on merge to master; prod hardened (guard + invalidate + verify)
+- **Merge to master → auto-deploy to preprod** (`preprod.hl7.org.au`, ungated), deploying the
+  D13-detected mode additively to the mirror bucket + CloudFront invalidation. preprod is the staging
+  validation step before a release. Required granting the OIDC role write to the mirror bucket
+  (terraform `publications_s3_scoped`, applied 2026-06-30; prod still gated by the `production` env).
+- **Prod release trigger = `v*` tag** (chosen over dispatch-only). The `publish-milestone` job is
+  hardened with: (1) a **release guard** — clean `X.Y.Z` version + milestone status, else fail (blocks
+  publishing a `-ci-build`/preview as prod "current"); (2) a **CloudFront invalidation**; (3) a
+  **post-publish verification** that fails the run if the new version + "current" pages aren't 200 on
+  `hl7.org.au`. `publish-working` gets the same invalidate + verify.

--- a/docs/pipeline-centralization.md
+++ b/docs/pipeline-centralization.md
@@ -80,14 +80,17 @@ created + verified on all three (reviewers `KyleOps` + `brettesler-ext` + `dt-r`
    a tag-triggered milestone publish is otherwise *rejected*. ✅
 4. **OIDC:** the `ghactions_publications_oidc` role trusts `repo:hl7au/*` — no per-repo IAM change. ✅
 
-## Deploy-target state (current — updated 2026-06-23)
+## Deploy-target state (current — updated 2026-06-30)
 
 | target | CI can write? | notes |
 |--------|---------------|-------|
-| previews bucket (`hl7au-fhir-ig-previews`) | ✅ | per-branch previews |
-| **`previews.hl7.org.au`** | ✅ live | CloudFront `E2V1L6CJ5AQEMV`; `enable_cdn=true` applied |
-| **`preprod.hl7.org.au`** | admin-manual | CloudFront `E1U9JOMOLLTC27`; prod mirror + dynamic-publish-box; not a CI target |
-| prod (`hl7au-fhir-ig` / `hl7.org.au`) | ✅ gated | `production` env configured — publish jobs now pause for approval (were dormant) |
+| **build.fhir.org** (dev preview) | — (external) | HL7 International's auto-builder; the build job links it. Our default dev preview. |
+| **`preprod.hl7.org.au`** | ✅ on merge to master | CloudFront `E1U9JOMOLLTC27`; mirror bucket now CI-writable (`deploy-preprod`, ungated); mode auto-detected from `status` |
+| **`hl7.org.au`** (prod) | ✅ gated (v* tag) | CloudFront `E2U6NB1JDLY5NT`; `production` env approval + release guard + invalidation + verify |
+| `previews.hl7.org.au` | ✅ opt-in | CloudFront `E2V1L6CJ5AQEMV`; our own preview, **off by default** (`enable_s3_preview: true`) |
+
+See [publication-process.md](./publication-process.md) and [decisions.md](./decisions.md) (D12–D14)
+for the build.fhir.org preview, preprod-on-merge, status-driven milestone detection, and prod hardening.
 
 ## Rollout order
 

--- a/docs/publication-process.md
+++ b/docs/publication-process.md
@@ -10,10 +10,15 @@ production. The logic lives once in the reusable workflow `.github/workflows/bui
 
 | event | what runs |
 |-------|-----------|
-| push to `master` | build + previews (no prod publish) |
-| pull request → `master` | build + previews (per-PR) |
-| push of a `v*` tag | build + previews + **publish-milestone** (gated) |
-| `workflow_dispatch` | build + previews; optional **publish-working** or **publish-milestone** (gated) |
+| pull request → `master` | build + reviewable .zip; dev preview = HL7 CI (build.fhir.org) |
+| push to `master` (merge) | build + **auto-deploy to preprod** (ungated; mode auto-detected) |
+| push of a `v*` tag | build + **publish-milestone to PROD** (gated by the `production` env) |
+| `workflow_dispatch` | build; optional **publish-working** / **publish-milestone** to prod (gated) |
+
+Developer previews are HL7 International's CI build at
+`https://build.fhir.org/ig/<org>/<repo>/branches/<branch>/` (rendered by HL7's own auto-builder, not
+this pipeline). Our own S3 preview channel is retained but **off by default** — pass
+`enable_s3_preview: true` only when validating our own pipeline/publisher output specifically.
 
 ## The build (one job, in the `hl7fhir/ig-publisher-base` container)
 
@@ -36,39 +41,59 @@ production. The logic lives once in the reusable workflow `.github/workflows/bui
 
 | host | CloudFront | bucket | purpose | who writes |
 |------|-----------|--------|---------|-----------|
-| **previews.hl7.org.au** | `E2V1L6CJ5AQEMV` | `hl7au-fhir-ig-previews` | per-branch working+milestone previews, path `/<slug>/{working,milestone}/fhir/…`; CachingDisabled; 30-day expiry | **CI** (every push/PR) |
-| **preprod.hl7.org.au** | `E1U9JOMOLLTC27` | `hl7au-fhir-ig-mirror` | prod mirror + dynamic-publish-box; full validation / migration review; reuses the `fhir-canonical` function | admin (S3→S3 sync; not CI) |
-| **hl7.org.au** (prod) | `E2U6NB1JDLY5NT` | `hl7au-fhir-ig` | production | CI, **gated** by the `production` environment |
+| **build.fhir.org** | — (HL7 International) | — | per-branch developer preview, rendered by HL7's auto-builder | HL7 CI (external) |
+| **preprod.hl7.org.au** | `E1U9JOMOLLTC27` | `hl7au-fhir-ig-mirror` | prod mirror + dynamic-publish-box; staging validation before a prod release; reuses the `fhir-canonical` function | **CI on merge to master** |
+| **hl7.org.au** (prod) | `E2U6NB1JDLY5NT` | `hl7au-fhir-ig` | production | CI, **gated** by the `production` environment (v* tag) |
+| previews.hl7.org.au | `E2V1L6CJ5AQEMV` | `hl7au-fhir-ig-previews` | our own per-branch preview, **off by default** (`enable_s3_preview: true`); CachingDisabled; 30-day expiry | CI (opt-in) |
 
 Infra is Terraform in `terraform/cloudfront` (HL7 AWS account `966489602583`, profile `hl7-mgmt`),
 the public-domain layer gated by `-var enable_cdn=true`.
 
-## Preview flow (every push / PR)
+## Developer preview (every push / PR)
 
-The `preview-s3` job downloads the artifact, seeds the history-template assets + preview-only redirects,
-assumes the OIDC role, and `aws s3 sync`s to `s3://hl7au-fhir-ig-previews/<slug>/`
-(`max_concurrent_requests=64` → ~2.5 min; decisions D8). Reviewers open:
+No deploy from us — the build job posts a link to HL7 International's CI build
+(`https://build.fhir.org/ig/<org>/<repo>/branches/<branch>/`) plus the downloadable `site-<slug>`
+artifact (the working + milestone renders as one tar.gz). To validate our **own** pipeline/publisher
+output (dynamic publish-box, combined jar, canonical behaviour), re-enable the S3 preview with
+`enable_s3_preview: true` — it deploys to `https://previews.hl7.org.au/<slug>/{working,milestone}/…`.
 
-```
-https://previews.hl7.org.au/<slug>/working/fhir/<version>/index.html
-https://previews.hl7.org.au/<slug>/milestone/fhir/<version>/index.html
-```
+## Preprod (auto, on merge to master)
 
-The dynamic publish-box resolves against the preview's own `package-list.json` (same-origin); baked
-absolute `hl7.org.au` canonicals resolve to prod. Cross-version comparison is present in both previews.
+The `deploy-preprod` job runs on every push to `master` (ungated) and syncs the detected build to the
+mirror bucket additively, then invalidates the preprod CloudFront. **Milestone vs working is
+auto-detected from `status` in `publication-request.json`** (the FHIR-standard signal, see
+decisions D13): `release`/`trial-use`/`normative`/`normative+trial-use` → **milestone** (preprod shows
+the candidate "current"); `draft`/`ballot`/`preview`/`update`/`ci-build` → **working** (a non-current
+versioned snapshot). preprod mirrors prod, so seeding the lean `-web` from live prod is correct here.
+Validate at `https://preprod.hl7.org.au/<owned>/<version>/index.html`, then cut the prod release.
 
-## Publishing to prod (gated)
+## Publishing to prod (gated — the rock-solid path)
 
-Both prod jobs declare `environment: production`, so they **pause for a required-reviewer approval**
-before any S3 write.
+`publish-milestone` declares `environment: production`, so it **pauses for a required-reviewer
+approval** before any S3 write. Triggered by a **`v*` tag** push (e.g. `git tag v6.1.0 && git push
+--tags`). Steps, in order:
 
-- **Milestone (becomes current):** push a `v*` tag (or dispatch with `publish_milestone=true`).
-  `publish-milestone` syncs `out/milestone/<owned>` to prod (additive) + the shared root files.
-- **Working (versioned snapshot, NOT current):** dispatch with `publish_working=true`.
-  `publish-working` syncs `out/working/<owned>` (does not touch the current landing or old versions).
+1. **Release guard** — fail unless the version is a clean SemVer release (`X.Y.Z`, no `-prerelease`
+   suffix) **and** the status is a milestone status (`release`/`trial-use`/`normative`). This blocks
+   publishing a `-ci-build`/draft/ballot/preview to prod as "current". Set `version` + `status` in
+   `publication-request.json` first, then tag `v<version>`.
+2. **Approval** — a `production` reviewer approves the waiting job.
+3. **Publish** — `aws s3 sync out/milestone/<owned>` to prod (additive) + the shared root files +
+   `package-registry.json`. With the dynamic publish-box there are **no rewritten old-version files**.
+4. **CloudFront invalidation** (`/*` on the prod distribution).
+5. **Post-publish verify** — fail the run if the new version page and the canonical "current" page
+   aren't returning 200 on `hl7.org.au` (retried).
 
-With the dynamic publish-box there are **no rewritten old-version files** — a publish only adds the new
-version dir + regenerates the owned-path root (history, package-list, redirects).
+`publish-working` (dispatch with `publish_working=true`, gated) publishes a non-current versioned
+snapshot the same way (sync + invalidate + verify), without touching the current landing or old versions.
+
+### Cut a production release (checklist)
+1. In the IG repo, set `publication-request.json` `version` = `X.Y.Z` (clean) and `status` =
+   `trial-use` (or `release`/`normative`); update `desc`/`sequence`. Open a PR, merge to `master`.
+2. The merge auto-deploys to **preprod** as a milestone — validate `https://preprod.hl7.org.au/<owned>/`.
+3. Tag the release: `git tag vX.Y.Z && git push origin vX.Y.Z`.
+4. Approve the **production** environment prompt on the Actions run.
+5. The run publishes, invalidates, and verifies prod automatically.
 
 ## The `production` environment gate — setup & process
 

--- a/terraform/cloudfront/iam.tf
+++ b/terraform/cloudfront/iam.tf
@@ -58,7 +58,10 @@ resource "aws_iam_role_policy" "publications_infra_iam" {
   })
 }
 
-# S3 access scoped to the content bucket + the Terraform state bucket only.
+# S3 access scoped to: content (prod), preprod-mirror, previews, and the Terraform-state bucket.
+# The preprod/mirror bucket is CI-writable so the pipeline can auto-deploy to preprod on merge to
+# master (build-review-publish.yml `deploy-preprod`). prod writes still happen only via the gated
+# `production` environment; preprod is ungated staging.
 resource "aws_iam_role_policy" "publications_s3_scoped" {
   name = "publications-s3-scoped"
   role = aws_iam_role.ghactions_publications_oidc.id
@@ -73,6 +76,8 @@ resource "aws_iam_role_policy" "publications_s3_scoped" {
         Resource = [
           "arn:aws:s3:::${local.content_bucket}",
           "arn:aws:s3:::${local.content_bucket}/*",
+          "arn:aws:s3:::${local.preprod_bucket}",
+          "arn:aws:s3:::${local.preprod_bucket}/*",
           "arn:aws:s3:::${local.previews_bucket}",
           "arn:aws:s3:::${local.previews_bucket}/*",
           "arn:aws:s3:::hl7au-publications-tfstate-ap-southeast-2",


### PR DESCRIPTION
## For review (Brett)

Updates the **central reusable pipeline** (used by AU Base / Core / PS via their caller stubs) to match what we agreed. Pairs with hl7au/au-fhir-base#1074 and hl7au/au-fhir-ps#145. Full rationale: `docs/decisions.md` (D12–D14), `docs/publication-process.md`.

### What changed
- **Developer preview = HL7 International's build.fhir.org** (per-branch, rendered by HL7's own auto-builder). We no longer deploy our own preview by default — the build job just links it + attaches the site `.zip`. Our S3 preview is kept but **off by default** (`enable_s3_preview: true` to re-enable, e.g. to test our own publisher output).
- **Merge to `master` → auto-deploy to preprod** (`preprod.hl7.org.au`), ungated. Milestone vs working is **auto-detected from `status` in `publication-request.json`** — the FHIR-standard signal (`trial-use`/`release`/`normative` → becomes "current"; `draft`/`ballot`/`preview`/`ci-build` → versioned snapshot). We confirmed against AU's own history that the version *number* isn't the signal (e.g. `2.0.0` shipped as `preview`).
- **Production release hardened.** Trigger = `vX.Y.Z` tag, gated by each repo's `production` environment, now with: a **release guard** (must be a clean `X.Y.Z` + milestone status — blocks publishing a `-ci-build`/preview as current), a **CloudFront invalidation**, and a **post-publish verification** (fails if the new pages aren't live).
- **Terraform:** granted the CI OIDC role write to the preprod mirror bucket (applied) so the preprod deploy works. Prod stays gated.

### New process at a glance
| trigger | result |
|---|---|
| PR | build + `build.fhir.org` preview link + `.zip` |
| merge to `master` | auto-deploy to **preprod** (mode auto-detected) |
| `v*` tag | **gated** prod publish + invalidate + verify |

No change to the `subtree` ownership model or the additive (never-delete) upload behaviour.