### PR TITLE
Publish working snapshots to prod automatically on release tags

### DIFF
--- a/.github/workflows/build-review-publish.yml
+++ b/.github/workflows/build-review-publish.yml
@@ -15,8 +15,13 @@ name: IG build → preprod (on merge) → gated prod publish (reusable)
 #     (milestone vs working) is AUTO-DETECTED from publication-request.json `status` (the FHIR-standard
 #     signal): release/trial-use/normative/normative+trial-use → milestone (becomes 'current');
 #     draft/ballot/preview/update/ci-build → working (versioned snapshot, not current).
-#   - On a v* TAG push → GATED publish to PROD (hl7.org.au), milestone, behind the caller repo's
-#     `production` environment, with a release guard + CloudFront invalidation + post-publish verify.
+#   - On a release-* / v* TAG push → publish to PROD (hl7.org.au). The tag is the release act; mode
+#     is auto-detected from publication-request.json `status` on the tagged commit:
+#       working (draft/ballot/preview — the frequent case) → publishes AUTOMATICALLY as a versioned
+#         snapshot ('current' untouched; additive only). Tag→version match is enforced.
+#       milestone (release/trial-use/normative — rewrites 'current'; ~annual) → GATED behind the
+#         caller repo's `production` environment (one reviewer click), plus the clean-release guard.
+#     Both paths end with CloudFront invalidation + post-publish verify.
 # github.* context inside this workflow reflects the CALLER's triggering event.
 #
 # PER-IG PARAMETER — `subtree`:
@@ -31,8 +36,9 @@ name: IG build → preprod (on merge) → gated prod publish (reusable)
 # DEPLOY TARGETS:
 #   - build.fhir.org (HL7 CI): developer previews — external, not written by us.
 #   - preprod (hl7au-fhir-ig-mirror / preprod.hl7.org.au): auto-deploy on merge to master. Ungated.
-#   - prod (hl7au-fhir-ig / hl7.org.au): GATED on the caller repo's `production` environment
-#     (required reviewers; deployment-branch rule = master + v* tags). v* tag only.
+#   - prod (hl7au-fhir-ig / hl7.org.au): release-*/v* tags. WORKING snapshots publish automatically
+#     (tag = approval); MILESTONE stays GATED on the caller repo's `production` environment
+#     (required reviewers; deployment rules must allow master + v* + release-* tags).
 #   - previews S3 (hl7au-fhir-ig-previews / previews.hl7.org.au): retained but OFF by default
 #     (enable_s3_preview=true to re-enable our own preview channel).
 #
@@ -58,7 +64,7 @@ on:
         type: boolean
         default: false
       publish_working:
-        description: "Publish the WORKING build to prod S3 (versioned snapshot, NOT current; gated)."
+        description: "Publish the WORKING build to prod S3 (versioned snapshot, NOT current; ungated — additive only)."
         type: boolean
         default: false
       enable_s3_preview:
@@ -99,6 +105,7 @@ jobs:
       version: ${{ steps.detect.outputs.version }}
       pubmode: ${{ steps.detect.outputs.pubmode }}
       release_ok: ${{ steps.detect.outputs.release_ok }}
+      tag_version_ok: ${{ steps.detect.outputs.tag_version_ok }}
     steps:
       - name: Compute build label (branch / pr-N / tag / dispatch ref) + owned path
         id: meta
@@ -130,6 +137,9 @@ jobs:
       #   draft | ballot | preview | update | ci-build | (other) → WORKING (versioned, not current)
       # release_ok additionally requires a clean SemVer release version (no -prerelease suffix), used
       # as the prod-publish guard so a -ci-build/preview can never be published to prod as 'current'.
+      # tag_version_ok: on tag pushes, the tag (minus its release-/v prefix) must equal the
+      # publication-request version — publishing is automatic on tags, so this is the guard against
+      # tagging the wrong commit (e.g. release-6.1.0 on a commit whose publication-request says 6.0.2).
       - name: Detect publication mode (status-driven)
         id: detect
         working-directory: ig-src
@@ -143,11 +153,17 @@ jobs:
           # clean release version = X.Y.Z with no -prerelease suffix
           relok=false
           if printf '%s' "$version" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+$' && [ "$pubmode" = "milestone" ]; then relok=true; fi
+          tagok=false; tagnorm=""
+          if [ "${{ github.ref_type }}" = "tag" ]; then
+            tagnorm="${{ github.ref_name }}"; tagnorm="${tagnorm#release-}"; tagnorm="${tagnorm#v}"
+            [ -n "$version" ] && [ "$tagnorm" = "$version" ] && tagok=true
+          fi
           echo "status=$status"   >> "$GITHUB_OUTPUT"
           echo "version=$version" >> "$GITHUB_OUTPUT"
           echo "pubmode=$pubmode" >> "$GITHUB_OUTPUT"
           echo "release_ok=$relok" >> "$GITHUB_OUTPUT"
-          echo "status='$status' version='$version' → pubmode=$pubmode (clean-release=$relok)"
+          echo "tag_version_ok=$tagok" >> "$GITHUB_OUTPUT"
+          echo "status='$status' version='$version' → pubmode=$pubmode (clean-release=$relok tag-match=$tagok)"
 
       - name: Checkout publish-setup.json + templates (sparse, from publications)
         uses: actions/checkout@v4
@@ -456,25 +472,31 @@ jobs:
             echo "- mode: **${{ needs.build.outputs.pubmode }}** (status \`${{ needs.build.outputs.status }}\`, version \`${{ needs.build.outputs.version }}\`)";
             echo "- https://preprod.hl7.org.au/$own/$ver/index.html";
             echo "- directory of versions: https://preprod.hl7.org.au/$own/history.html";
-            echo "_Validate here, then cut a prod release by pushing a \`v*\` tag (gated by the production environment)._";
+            echo "_Validate here, then cut a prod release by pushing a \`release-<version>\` tag: a working status publishes automatically as a versioned snapshot; a milestone status waits for one production-environment approval._";
           } >> "$GITHUB_STEP_SUMMARY"
 
-  # Promote the MILESTONE build to PROD — gated by the caller repo's `production` environment (required
-  # reviewers; deployment-branch rule = master + v* tags). Runs ONLY on a version-tag push or an explicit
-  # dispatch with publish_milestone=true.
+  # Promote the MILESTONE build to PROD — a milestone rewrites 'current', so it stays gated by the
+  # caller repo's `production` environment (required reviewers; deployment rules = master + v* +
+  # release-* tags). Runs on a tag push whose publication-request status detects as milestone, or an
+  # explicit dispatch with publish_milestone=true.
   publish-milestone:
     needs: build   # not preview-s3: a preview hiccup must not block prod; the production env is the gate
-    if: ${{ (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')) || (github.event_name == 'workflow_dispatch' && inputs.publish_milestone) }}
+    if: ${{ (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/') && needs.build.outputs.pubmode == 'milestone') || (github.event_name == 'workflow_dispatch' && inputs.publish_milestone) }}
     runs-on: ubuntu-latest
     environment: production
     steps:
       # Release guard: a prod milestone must be a clean SemVer release (X.Y.Z, no -prerelease suffix)
       # with a milestone status (release/trial-use/normative). Blocks accidentally publishing a
       # -ci-build/draft/ballot/preview as prod 'current'. (release_ok is computed in the build job.)
+      # On tag pushes the tag must also name the version being published (tag_version_ok).
       - name: Guard — require a clean release version + milestone status
         run: |
           if [ "${{ needs.build.outputs.release_ok }}" != "true" ]; then
-            echo "::error::Refusing to publish to PROD: version='${{ needs.build.outputs.version }}' status='${{ needs.build.outputs.status }}'. A prod milestone needs a clean release version (X.Y.Z) and a release/trial-use/normative status. Set version + status in publication-request.json, then tag v<version>."
+            echo "::error::Refusing to publish to PROD: version='${{ needs.build.outputs.version }}' status='${{ needs.build.outputs.status }}'. A prod milestone needs a clean release version (X.Y.Z) and a release/trial-use/normative status. Set version + status in publication-request.json, then tag release-<version>."
+            exit 1
+          fi
+          if [ "${{ github.ref_type }}" = "tag" ] && [ "${{ needs.build.outputs.tag_version_ok }}" != "true" ]; then
+            echo "::error::Tag '${{ github.ref_name }}' does not match publication-request.json version '${{ needs.build.outputs.version }}' — refusing to publish. Tag the commit whose publication-request names this version (release-<version>)."
             exit 1
           fi
           echo "Release guard OK: version=${{ needs.build.outputs.version }} status=${{ needs.build.outputs.status }}"
@@ -531,15 +553,25 @@ jobs:
           } >> "$GITHUB_STEP_SUMMARY"
           exit $fail
 
-  # Publish the WORKING build to PROD — the common case (preview/ballot/draft). Gated by the same
-  # `production` environment. Dispatch-only (publish_working=true), mutually exclusive with
-  # publish_milestone so a v* tag never publishes a working snapshot as current.
+  # Publish the WORKING build to PROD — the common case (preview/ballot/draft). Runs AUTOMATICALLY on
+  # a tag push whose status detects as working: the tag is the release act, no approval click. Safe to
+  # leave ungated because a working publish is strictly additive (new versioned dir + regenerated
+  # owned-path root; 'current' and old versions untouched) and the tag→version guard below stops a
+  # mistagged commit. Also runnable via dispatch (publish_working=true), mutually exclusive with
+  # publish_milestone. Same OIDC role as deploy-preprod — no environment needed (trust = repo:hl7au/*).
   publish-working:
     needs: build
-    if: ${{ github.event_name == 'workflow_dispatch' && inputs.publish_working && !inputs.publish_milestone }}
+    if: ${{ (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/') && needs.build.outputs.pubmode == 'working') || (github.event_name == 'workflow_dispatch' && inputs.publish_working && !inputs.publish_milestone) }}
     runs-on: ubuntu-latest
-    environment: production
     steps:
+      - name: Guard — tag must name the version being published
+        if: ${{ github.ref_type == 'tag' }}
+        run: |
+          if [ "${{ needs.build.outputs.tag_version_ok }}" != "true" ]; then
+            echo "::error::Tag '${{ github.ref_name }}' does not match publication-request.json version '${{ needs.build.outputs.version }}' — refusing to publish. Tag the commit whose publication-request names this version (release-<version>)."
+            exit 1
+          fi
+          echo "Tag guard OK: ${{ github.ref_name }} → version ${{ needs.build.outputs.version }} (status ${{ needs.build.outputs.status }})"
       - name: Download reviewed previews
         uses: actions/download-artifact@v4
         with: { name: "site-${{ needs.build.outputs.slug }}" }


### PR DESCRIPTION
Makes the prod release flow match how releases are actually cut: push a `release-<version>` (or `v<version>`) tag and the pipeline publishes, choosing the path from `publication-request.json` `status` on the tagged commit:

| status on tagged commit | path | gate |
|---|---|---|
| draft / ballot / preview (**working**) — the frequent case | versioned snapshot, `current` untouched, additive only | **automatic** — the tag is the approval; tag→version guard |
| release / trial-use / normative (**milestone**) — rewrites `current` | full milestone promote | `production` environment approval (unchanged) + clean-release guard + tag→version guard |

Previously a tag only routed to the milestone job (draft tags failed its release guard and published nothing) and working publishes were dispatch-only, so routine draft releases needed a manual `workflow_dispatch`.

**New guard:** on any tag publish, the tag minus its `release-`/`v` prefix must equal the publication-request version, so tagging the wrong commit refuses loudly instead of publishing the wrong content.

**Companion changes** (caller repos): forward `release-*` tags in the caller stub (hl7au/au-fhir-base#1080) and allow `release-*` in the `production` environment deployment rules.

`publish-working` no longer uses the `production` environment; it assumes the same repo-scoped OIDC role as the ungated preprod deploy (trust policy is `repo:hl7au/*`, not environment-scoped).