### PR TITLE
Symlink default ~/.fhir/packages to the cached package folder

### DIFF
--- a/.github/workflows/build-review-publish.yml
+++ b/.github/workflows/build-review-publish.yml
@@ -216,6 +216,12 @@ jobs:
       # Keyed on the IG's dependency declarations (ig.xml dependsOn + ig.ini); restore-keys falls back
       # to the latest cache and the render just adds anything new. NOTE: only the -ig render honors
       # -package-cache-folder; go-publish ignores it, but -reuse-build makes go-publish skip the render.
+      # The render step also symlinks ~/.fhir/packages to this folder: several code paths hardwire the
+      # DEFAULT cache location — go-publish, and the validator's ImplementationGuide.dependsOn check,
+      # which builds its own FilesystemPackageCacheManager. With a cold default cache that check falls
+      # through to a fuzzy npm catalog search and reports bogus canonical clashes (e.g. packageId
+      # hl7.terminology.r4 "pointing to" packages2's hl7.terminology.r4b web tgz) — 5 spurious QA
+      # errors on the au-core 2.1.0-draft release that build.fhir.org (warm default cache) never shows.
       - name: Cache FHIR packages (speeds up the render)
         uses: actions/cache@v4
         with:
@@ -245,6 +251,9 @@ jobs:
           # runs below can adopt it (no re-render). Path (not mode) drives the reuse match, so flipping
           # mode for each preview below still reuses this one render.
           mkdir -p "$GITHUB_WORKSPACE/.fhir-cache"
+          # Unify the DEFAULT package-cache location with the cached folder (see the cache step note):
+          # kills the spurious dependsOn canonical-clash QA errors and lets go-publish reuse the cache.
+          mkdir -p "$HOME/.fhir" && rm -rf "$HOME/.fhir/packages" && ln -sfn "$GITHUB_WORKSPACE/.fhir-cache" "$HOME/.fhir/packages"
           PUBPATH=$(grep -o '"path"[^,}]*' publication-request.json | head -1 | sed 's/.*:[[:space:]]*"\([^"]*\)".*/\1/')
           echo "Publication path: $PUBPATH"
           echo "ver=${PUBPATH##*/}" >> "$GITHUB_OUTPUT"   # version folder name, for preview deep-links


### PR DESCRIPTION
Fixes the 5 spurious QA errors on the au-core 2.1.0-draft release ([qa.html](https://hl7.org.au/fhir/core/2.1.0-draft/qa.html)) of the form:

> The packageId hl7.terminology.r4 points to the canonical https://packages2.fhir.org/web/hl7.terminology.r4b-6.0.2.tgz which is inconsistent with the stated canonical …

**Root cause** (upstream, present in stock 2.2.10 — not the AU jar patches): the validator's `ImplementationGuide.dependsOn` check constructs its own `FilesystemPackageCacheManager` at the **default** `~/.fhir/packages`, ignoring `-package-cache-folder`. On a cache miss, `getPackageUrl()` falls through to the npm catalog's substring name-search and takes the **first hit's url** as the canonical — `hl7.terminology.r4` fuzzy-matches `hl7.terminology.r4b`, whose packages2 catalog entry carries its web tgz path. Our runners keep the package cache in `$GITHUB_WORKSPACE/.fhir-cache` (actions/cache), so the default location is cold and every dependsOn lookup takes the fuzzy path; build.fhir.org has a warm default cache and resolves locally, which is why its CI builds never show the errors.

**Fix:** symlink `~/.fhir/packages` → `$GITHUB_WORKSPACE/.fhir-cache` before the render, so every code path that hardwires the default location (the validator check, and go-publish's own package fetches, which also ignore `-package-cache-folder`) sees the same warm cache.

Package *content* was never affected — `package.json` in the published packages has the correct dependency versions; only the QA cross-check misfired. Worth also filing upstream: (a) the validator should honor the configured package cache; (b) `getPackageUrl` should exact-match the package name rather than trusting the first fuzzy catalog hit.