### PR TITLE
Add a QA regression gate (error summary + PR gate + PR comment)

### DIFF
--- a/.github/workflows/build-review-publish.yml
+++ b/.github/workflows/build-review-publish.yml
@@ -77,8 +77,9 @@ on:
         default: false
 
 permissions:
-  id-token: write   # OIDC → AWS (preprod deploy + gated prod publish + optional S3 preview)
+  id-token: write        # OIDC → AWS (preprod deploy + gated prod publish + optional S3 preview)
   contents: read
+  pull-requests: write   # QA gate: comment the QA summary on the triggering PR (needs the caller stub to grant it too)
 
 concurrency:
   group: ig-publish-${{ github.repository }}   # serialise each IG against itself; siblings independent
@@ -363,6 +364,100 @@ jobs:
             echo "- **Reviewable build (this run):** the \`site-${{ steps.meta.outputs.slug }}\` artifact below — a tar.gz of the working + milestone renders.";
             echo "- detected publication mode: **${{ steps.detect.outputs.pubmode }}** (status \`${{ steps.detect.outputs.status }}\`, version \`${{ steps.detect.outputs.version }}\`)";
           } >> "$GITHUB_STEP_SUMMARY"
+
+      # ---- QA regression gate --------------------------------------------------------------------
+      # Summarise the render's QA errors to the run summary; on PRs, compare the error count against
+      # the base branch's last recorded count and FAIL if the branch adds errors; and upsert a comment
+      # on the triggering PR. The baseline is a tiny cached count file, written on branch pushes and
+      # restored (keyed by base branch) on PRs — so both sides are the same pipeline and same jar.
+      # Runs after the previews so a regressed PR still produces its reviewable artifact.
+      - name: Restore base QA baseline (PRs)
+        if: github.event_name == 'pull_request'
+        uses: actions/cache/restore@v4
+        with:
+          path: qa-baseline
+          key: qa-baseline-${{ github.repository }}-${{ github.base_ref }}-${{ github.run_id }}
+          restore-keys: |
+            qa-baseline-${{ github.repository }}-${{ github.base_ref }}-
+
+      - name: Analyse QA, summarise, gate PRs, comment
+        if: always() && steps.render.outcome == 'success'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          EVENT: ${{ github.event_name }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          BASE_REF: ${{ github.base_ref }}
+          SLUG: ${{ steps.meta.outputs.slug }}
+        run: |
+          qa="ig-src/output/qa.txt"
+          if [ ! -f "$qa" ]; then echo "::warning::no qa.txt at $qa — skipping QA gate"; exit 0; fi
+          num() { grep -oE "$1 = [0-9]+" "$qa" | head -1 | grep -oE '[0-9]+' || true; }
+          errs=$(num err);   errs=${errs:-0}
+          warns=$(num warn); warns=${warns:-0}
+          infos=$(num info); infos=${infos:-0}
+          grep '^ERROR:' "$qa" | sed -E 's/ \(error message.*//' > qa-errors.txt || true
+
+          base_errs=""
+          [ -f qa-baseline/count.txt ] && base_errs=$(tr -cd '0-9' < qa-baseline/count.txt)
+
+          {
+            echo "## QA results — \`$SLUG\`"
+            echo ""
+            echo "| level | count |"
+            echo "|---|--:|"
+            echo "| ❌ errors | $errs |"
+            echo "| ⚠️ warnings | $warns |"
+            echo "| ℹ️ info | $infos |"
+            if [ -n "$base_errs" ]; then
+              d=$((errs - base_errs)); sign=""; [ "$d" -gt 0 ] && sign="+"
+              echo ""
+              echo "Errors vs base \`$BASE_REF\`: **$base_errs → $errs** (${sign}${d})"
+            fi
+            if [ "$errs" -gt 0 ]; then
+              echo ""; echo "<details><summary>$errs error(s)</summary>"; echo ""
+              echo '```'; cat qa-errors.txt; echo '```'; echo ""; echo "</details>"
+            fi
+          } > qa-summary.md
+          cat qa-summary.md >> "$GITHUB_STEP_SUMMARY"
+
+          # PR comment (best-effort; needs pull-requests: write granted by the caller stub)
+          if [ "$EVENT" = "pull_request" ] && [ -n "${PR_NUMBER:-}" ]; then
+            { printf '<!-- qa-gate -->\n'; cat qa-summary.md; } > qa-comment.md
+            node -e 'const fs=require("fs");process.stdout.write(JSON.stringify({body:fs.readFileSync("qa-comment.md","utf8")}))' > qa-payload.json
+            api="https://api.github.com/repos/$REPO"
+            cid=$(curl -sS -H "Authorization: Bearer $GH_TOKEN" -H "Accept: application/vnd.github+json" \
+              "$api/issues/$PR_NUMBER/comments?per_page=100" \
+              | node -e 'const d=JSON.parse(require("fs").readFileSync(0,"utf8")||"[]");const c=(Array.isArray(d)?d:[]).find(x=>x.body&&x.body.includes("<!-- qa-gate -->"));process.stdout.write(c?String(c.id):"")' || true)
+            if [ -n "$cid" ]; then
+              curl -sS -X PATCH -H "Authorization: Bearer $GH_TOKEN" -H "Accept: application/vnd.github+json" \
+                "$api/issues/comments/$cid" -d @qa-payload.json >/dev/null && echo "updated PR #$PR_NUMBER comment" \
+                || echo "::warning::could not update PR comment (grant pull-requests: write in the caller)"
+            else
+              curl -sS -X POST -H "Authorization: Bearer $GH_TOKEN" -H "Accept: application/vnd.github+json" \
+                "$api/issues/$PR_NUMBER/comments" -d @qa-payload.json >/dev/null && echo "posted PR #$PR_NUMBER comment" \
+                || echo "::warning::could not post PR comment (grant pull-requests: write in the caller)"
+            fi
+          fi
+
+          # Record this build's error count as the branch baseline (cached by the save step on pushes).
+          mkdir -p qa-baseline
+          echo "$errs" > qa-baseline/count.txt
+          cp qa-errors.txt qa-baseline/errors.txt 2>/dev/null || true
+
+          # Gate: a PR may not add errors over its base branch.
+          if [ "$EVENT" = "pull_request" ] && [ -n "$base_errs" ] && [ "$errs" -gt "$base_errs" ]; then
+            echo "::error::QA regression — $errs error(s) vs base \`$BASE_REF\` ($base_errs). Resolve the new errors before merging."
+            exit 1
+          fi
+          echo "QA gate OK — errors=$errs, base=${base_errs:-n/a}"
+
+      - name: Save QA baseline (branch pushes)
+        if: github.event_name == 'push' && github.ref_type == 'branch' && steps.render.outcome == 'success'
+        uses: actions/cache/save@v4
+        with:
+          path: qa-baseline
+          key: qa-baseline-${{ github.repository }}-${{ github.ref_name }}-${{ github.run_id }}
 
   # OUR OWN per-branch S3 previews (previews.hl7.org.au) — RETAINED but OFF by default. The developer
   # preview channel is HL7 International's build.fhir.org (see the build job's report). Re-enable this


### PR DESCRIPTION
Adds a QA step-group at the end of the `build` job that turns the render QA into a review signal.

## What it does
After the working/milestone previews build (so a regressed PR still produces its reviewable artifact), it parses `ig-src/output/qa.txt` and:

1. **Run summary** — writes an errors/warnings/info table plus the collapsed error list to `$GITHUB_STEP_SUMMARY` on every run.
2. **PR gate** — on `pull_request` runs, compares the error count to the base branch's last recorded count and **fails the run if the branch adds errors**.
3. **PR comment** — on `pull_request` runs, upserts (marker-based, no spam) a comment on the triggering PR with the same summary.

## How "base" is determined
A tiny count file cached per branch: **saved on branch pushes**, **restored keyed by the PR base branch** on PRs. Both sides are therefore the same pipeline and the same combined jar (so the comparison is apples-to-apples, unlike build.fhir.org which uses the stock publisher). If no baseline exists yet (first runs), it reports `n/a` and does **not** gate.

## Notes / follow-up
- The PR comment is **best-effort** and needs `pull-requests: write`. This workflow now requests it, but for reusable workflows the **caller stub must also grant it** (`permissions: pull-requests: write`) or the comment step just logs a warning and continues. The summary and the gate work regardless. Happy to follow up with caller-stub PRs to enable comments across au-base/core/ps.
- Parsing is on `qa.txt` (the `err = N, warn = N, info = N` summary and `^ERROR:` lines) rather than `qa.json`, to avoid coupling to the JSON schema.
- Placed after the previews and guarded with `if: always() && steps.render.outcome == 'success'`, so the gate never suppresses the artifact and only runs when there is a render to analyse.